### PR TITLE
Specs: Add File to Experience + Standard Controller Tests

### DIFF
--- a/spec/controllers/experiences_controller_spec.rb
+++ b/spec/controllers/experiences_controller_spec.rb
@@ -33,14 +33,16 @@ describe ExperiencesController do
     {
       description: 'this is a pretty bland description',
       theme_id: third_fragment.id,
-      published: 'true'
+      published: 'true',
+      file: Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec', 'support', 'files','inflation.xls'))
     }
   }
 
   let(:draft_entity) {
     {
-        description: 'this is a pretty bland description',
-        theme_id: third_fragment.id,
+      description: 'this is a pretty bland description',
+      theme_id: third_fragment.id,
+      file: Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec', 'support', 'files','inflation.xls'))
     }
   }
 
@@ -54,7 +56,8 @@ describe ExperiencesController do
   let(:valid_patch_model) {
     {
       description: 'This is a much, much better description!!',
-      link: 'http://www.yahoo.com'
+      link: 'http://www.yahoo.com',
+      file: Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec', 'support', 'files','inflation.xls'))
     }
   }
 
@@ -62,8 +65,8 @@ describe ExperiencesController do
     {
       description: 'This is a much, much better description!!',
       link: 'http://www.yahoo.com',
-      file: Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec', 'support', 'files','inflation.xls')),
-      published: 'true'
+      published: 'true',
+      file: Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec', 'support', 'files','inflation.xls'))
     }
   }
 

--- a/spec/support/standard_controller_actions.rb
+++ b/spec/support/standard_controller_actions.rb
@@ -126,6 +126,8 @@ shared_examples_for 'a standard controller' do
                :"#{underscore(third_fragment.class)}_id" => third_fragment.id,
                :"#{target_model}" => savable_entity
           expect(assigns(target_model).published_at).to_not be_nil
+          expect(assigns(target_model).description).to eq savable_entity[:description]
+          # expect(assigns(target_model).file).to be_present
           expect(assigns(target_model).persisted?).to eq true
         end
 
@@ -135,6 +137,8 @@ shared_examples_for 'a standard controller' do
                :"#{underscore(third_fragment.class)}_id" => third_fragment.id,
                :"#{target_model}" => draft_entity
           expect(assigns(target_model).published_at).to be_nil
+          expect(assigns(target_model).description).to eq draft_entity[:description]
+          # expect(assigns(target_model).file).to be_present
           expect(assigns(target_model).persisted?).to eq true
         end
 
@@ -227,6 +231,7 @@ shared_examples_for 'a standard controller' do
 
         expect(assigns(target_model).link).to eq valid_patch_model[:link]
         expect(assigns(target_model).description).to eq valid_patch_model[:description]
+        # expect(assigns(target_model).file).to be_present
         expect(assigns(target_model).persisted?).to eq true
         expect(assigns(target_model).published_at).to be_nil
       end
@@ -260,6 +265,7 @@ shared_examples_for 'a standard controller' do
 
         expect(assigns(target_model).link).to eq valid_patch_publish_model[:link]
         expect(assigns(target_model).description).to eq valid_patch_publish_model[:description]
+        # expect(assigns(target_model).file).to be_present
         expect(assigns(target_model).persisted?).to eq true
         expect(assigns(target_model).published_at).to_not be_nil
       end


### PR DESCRIPTION
**What**
This approach will test our file uploads for each of the objects we're including them with - eventually we can use this for all the main objects (I've left the tests commented out for now waiting for us to complete the entire suite of attachments available on each object). Once they're all merged, we should create another PR to uncomment the standard controller action tests.
