### PR TITLE
Update: Allow for role to be set on onboard page and reordered fields

### DIFF
--- a/app/controllers/concerns/routing_concern.rb
+++ b/app/controllers/concerns/routing_concern.rb
@@ -4,8 +4,11 @@ module RoutingConcern
   ## DEVISE ROUTING
   def after_sign_in_path_for(resource)
     persist_pending_cache
-    complete_profile_request
-    super
+    if resource.profile_complete?
+      super
+    else
+      edit_user_registration_path(setting: 'onboard')
+    end
   end
 
   ## OBJECT PERSISTENCE ROUTING
@@ -59,13 +62,6 @@ module RoutingConcern
 
   def path_to_url(path)
     "#{ENV.fetch('SITE_PROTOCOL')}://#{ENV.fetch('SITE_HOST')}#{path}"
-  end
-
-private
-
-  def complete_profile_request
-    flash[:notice] += " Please <a href='#{edit_user_registration_url(setting: 'onboard')}'>complete your profile</a>." if resource.sign_in_count < 5 && !resource.profile_complete?
-  rescue
   end
 
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -59,7 +59,8 @@ private
   end
 
   def after_update_path_for(resource)
-    edit_user_registration_path(setting: (@setting == 'onboard' ? 'profile': "#{@setting}"))
+    stored_location_for(resource) ||
+      edit_user_registration_path(setting: (@setting == 'onboard' ? 'profile': "#{@setting}"))
   end
 
   def update_avatar(resource)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,13 +45,14 @@ class User < ActiveRecord::Base
   MAX_AVATAR_SIZE = 3
 
   ## VALIDATIONS
-  validates :first_name,    length: { maximum: 255 }, presence: true
-  validates :last_name,     length: { maximum: 255 }, presence: true
-  validates :role,          length: { maximum: 255 }, presence: true
-  validates :display_name,  length: { maximum: 255 }, presence: true, on: :update
+  validates :first_name,    presence: true, length: { maximum: 255 }
+  validates :last_name,     presence: true, length: { maximum: 255 }
+  validates :display_name,  presence: true, length: { maximum: 255 }, on: :update
+  validates :role,          presence: true, length: { maximum: 255 }, on: :update
   validates :organization,  length: { maximum: 255 }, allow_blank: true
   validates :title,         length: { maximum: 255 }, allow_blank: true
   validates :twitter,       length: { maximum: 16 },  allow_blank: true
+  validates :twitter,       presence: true, if: "avatar_option == 'twitter'"
   validate  :avatar_file_size
 
   def name
@@ -77,7 +78,7 @@ class User < ActiveRecord::Base
   end
 
   def profile_complete?
-    organization.present? || title.present? || twitter.present? || states.present? || districts.present? || schools.present?
+    role.present? || organization.present? || title.present? || twitter.present? || states.present? || districts.present? || schools.present?
   end
 
   def states_json
@@ -92,8 +93,8 @@ class User < ActiveRecord::Base
     schools.to_json(only: [:id, :name, :location_city, :location_state])
   end
 
-  def is_teacher?
-    ['Current Teacher', 'Teacher Leader', 'Instructional Coach', 'School Leader'].include?(role)
+  def is_school_role?
+    ['Student', 'Current Teacher', 'Teacher Leader', 'Instructional Coach', 'School Leader'].include?(role)
   end
 
   def is_on_panel?(challenge)
@@ -132,6 +133,7 @@ class User < ActiveRecord::Base
   # <p class='select-help'>I am an administrator in a school (principal, assistant principal, dean, etc.).</p>
 
   ROLES = {
+    'Student' => 'Student',
     'Pre-Service Teacher' => 'Pre-Service Teacher',
     'Current Teacher' => 'Current Teacher',
     'Teacher Leader' => 'Teacher Leader',

--- a/app/views/devise/registrations/forms/_profile.html.erb
+++ b/app/views/devise/registrations/forms/_profile.html.erb
@@ -2,29 +2,9 @@
   <%= f.hidden_field :setting, value: params[:setting] %>
   <%= devise_error_messages! %>
 
-  <div class='form-group'>
-    <%= f.label :display_name, "Name you would like to go by" %>
-    <div class="input-group">
-      <span class="input-group-addon"><i class='fa fa-user'></i></span>
-      <%= f.text_field :display_name, class: 'form-control' %>
-    </div>
-  </div>
-
-  <div class='form-group'>
-    <%= f.label :twitter %>
-    <div class="input-group">
-      <span class="input-group-addon"><i class='fa fa-at'></i></span>
-      <%= f.text_field :twitter, class: 'form-control', maxlength: "16" %>
-    </div>
-  </div>
-
-  <%= render partial: 'devise/registrations/forms/avatar', locals: { f: f } %>
-
-  <hr>
-
-  <div class='form-group <%= 'hidden' if @setting == 'onboard' %>' ng-init="role='<%= resource.role %>'">
-    <%= f.label :role, "Which option best describes your role?" %>
-    <%= f.select :role, options_for_select(User::ROLES, (resource.role if resource.role)), { prompt: "Select One" }, class: 'form-control', 'ng-model' => 'role' %>
+  <div class='form-group' ng-init="role='<%= resource.role %>'">
+    <%= f.label :role, "Which option best describes your role?*" %>
+    <%= f.select :role, options_for_select(User::ROLES, (resource.role if resource.role)), { prompt: "Select One" }, required: true, class: 'form-control', 'ng-model' => 'role' %>
   </div>
 
   <div class="form-group" ng-show="role == 'SEA Staff'">
@@ -105,10 +85,10 @@
     </script>
   </div>
 
-  <div ng-init="other_school=<%= resource.is_teacher? && resource.schools.empty? && resource.organization.present? %>"></div>
-  <div class="form-group" ng-show="role == 'Current Teacher' || role == 'Teacher Leader' || role == 'Instructional Coach' || role == 'School Leader'" ng-controller='SchoolCtrl' ng-class="{ 'zero-margin-bottom' : other_school }">
+  <div ng-init="other_school=<%= resource.is_school_role? && resource.schools.empty? && resource.organization.present? %>"></div>
+  <div class="form-group" ng-show="role == 'Student' || role == 'Current Teacher' || role == 'Teacher Leader' || role == 'Instructional Coach' || role == 'School Leader'" ng-controller='SchoolCtrl' ng-class="{ 'zero-margin-bottom' : other_school }">
     <label for='user_school_ids'>
-      Which school(s) do you serve?
+      {{ role == 'Student' ? 'Which school do you attend?' : 'Which school(s) do you serve?' }}
       <small>
         <a href='#' onclick='return false;' ng-hide='other_school' ng-click="otherSchool(true)">Can't find your school?</a>
         <a href='#' onclick='return false;' ng-show='other_school' ng-click="otherSchool(false)">Go to prepopulated list of schools.</a>
@@ -146,7 +126,7 @@
     </script>
   </div>
 
-  <div class='form-group' ng-show="role == 'Other' || role == 'Pre-Service Teacher' || (role == 'LEA Staff' && other_lea) || ((role == 'Current Teacher' || role == 'Teacher Leader' || role == 'Instructional Coach' || role == 'School Leader') && other_school) && role != 'SEA Staff'" ng-init="organization='<%= resource.organization %>'">
+  <div class='form-group' ng-show="role == 'Other' || role == 'Pre-Service Teacher' || (role == 'LEA Staff' && other_lea) || ((role == 'Student' || role == 'Current Teacher' || role == 'Teacher Leader' || role == 'Instructional Coach' || role == 'School Leader') && other_school) && role != 'SEA Staff'" ng-init="organization='<%= resource.organization %>'">
     <%= f.label :organization, "Which organization do you work for?", 'ng-show' => 'role == "Other"' %>
     <%= f.label :organization, "Which teacher training institution do you attend?", 'ng-show' => 'role == "Pre-Service Teacher"' %>
     <%= f.text_field :organization, class: 'form-control', placeholder: "{{ role != 'Other' && role != 'Pre-Service Teacher' ? other_placeholder : ''}}", 'ng-model' => 'organization' %>
@@ -155,11 +135,32 @@
   <div class='form-group' ng-show='role && role != "Pre-Service Teacher"' ng-init="title='<%= resource.title %>'">
     <label for='user_title' ng-show="role == 'LEA Staff' || role == 'SEA Staff' || role == 'Other'">What is your title?</label>
     <label for='user_title' ng-show="role == 'Current Teacher' || role == 'Teacher Leader' || role == 'Instructional Coach' || role == 'School Leader'">Which grade(s) and subject area(s) do you support/teach?</label>
+    <label for='user_title' ng-show="role == 'Student'">What grade are you in?</label>
     <%= f.text_field :title, class: 'form-control', 'ng-model' => 'title' %>
   </div>
 
+  <hr>
+
   <div class='form-group'>
-    <%= f.label :bio, "Interests and expertise" %>
+    <%= f.label :display_name, "Name you would like to go by*" %>
+    <div class="input-group">
+      <span class="input-group-addon"><i class='fa fa-user'></i></span>
+      <%= f.text_field :display_name, class: 'form-control', required: true %>
+    </div>
+  </div>
+
+  <%= render partial: 'devise/registrations/forms/avatar', locals: { f: f } %>
+
+  <div class='form-group'>
+    <%= f.label :twitter, "Twitter".html_safe %>
+    <div class="input-group">
+      <span class="input-group-addon"><i class='fa fa-at'></i></span>
+      <%= f.text_field :twitter, class: 'form-control', maxlength: "16" %>
+    </div>
+  </div>
+
+  <div class='form-group'>
+    <%= f.label :bio, "Interests and expertise".html_safe %>
     <%= f.text_area :bio, class: 'form-control', placeholder: "Let other community members learn a bit more about you.", rows: 3 %>
   </div>
 

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -6,16 +6,16 @@ describe RegistrationsController do
   describe 'PATCH #update' do
 
     let(:user) {
-      create(:user, avatar_option: 'twitter')
+      create(:user)
     }
 
     let(:upload) {
       ActionDispatch::Http::UploadedFile.new(
-          {
-              filename: 'avatar.png',
-              content_type: 'image/png',
-              tempfile: File.new("#{Rails.root}/spec/support/images/small_image.png")
-          }
+        {
+          filename: 'avatar.png',
+          content_type: 'image/png',
+          tempfile: File.new("#{Rails.root}/spec/support/images/small_image.png")
+        }
       )
     }
 
@@ -57,8 +57,7 @@ describe RegistrationsController do
         first_name: "James",
         last_name: "Bond",
         email: "bond@goldeneye.com",
-        password: "0nh3rm4j357y'553cr3753rv1c3",
-        role: 'Current Teacher'
+        password: "0nh3rm4j357y'553cr3753rv1c3"
       }
     }
 
@@ -68,7 +67,6 @@ describe RegistrationsController do
         last_name: "Bond",
         email: "bond@goldeneye",
         password: "0nh3rm4j357y'553cr3753rv1c3",
-        role: 'Current Teacher'
       }
     }
 

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -13,6 +13,8 @@ FactoryGirl.define do
     sequence :email do |n|
       "testname#{n}@example.com"
     end
+
+    before(:create) { |user| user.display_name = "#{user.first_name} #{user.last_name[0]}" }
   end
   #
   # trait :with_small_avatar_file do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,19 +11,20 @@ describe User do
   it { is_expected.to have_many(:recipes) }
   it { is_expected.to have_many(:solutions) }
   it { is_expected.to have_many(:comments) }
-  it { is_expected.to belong_to(:referrer).class_name('User').with_foreign_key(:referrer_id)}
-  it { is_expected.to have_many(:referrals).class_name('User').with_foreign_key(:referrer_id)}
+  it { is_expected.to belong_to(:referrer).class_name('User').with_foreign_key(:referrer_id) }
+  it { is_expected.to have_many(:referrals).class_name('User').with_foreign_key(:referrer_id) }
 
   it { is_expected.to validate_presence_of(:first_name) }
   it { is_expected.to validate_length_of(:first_name).is_at_most(255) }
   it { is_expected.to validate_presence_of(:last_name) }
   it { is_expected.to validate_length_of(:last_name).is_at_most(255) }
-  it { is_expected.to validate_presence_of(:role) }
-  it { is_expected.to validate_length_of(:role).is_at_most(255) }
+  it { is_expected.to validate_presence_of(:display_name).on(:update) }
+  it { is_expected.to validate_length_of(:display_name).is_at_most(255).on(:update) }
+  it { is_expected.to validate_presence_of(:role).on(:update) }
+  it { is_expected.to validate_length_of(:role).is_at_most(255).on(:update) }
   it { is_expected.to validate_length_of(:organization).is_at_most(255) }
   it { is_expected.to validate_length_of(:title).is_at_most(255) }
   it { is_expected.to validate_length_of(:twitter).is_at_most(16) }
-  # it { is_expected.to validate_length_of(:bio).is_at_most(2047) }
 
   describe '#has_draft_submissions?' do
     context 'with an entity that is unpublished' do


### PR DESCRIPTION
**What**
Pre-requisite to have role be set once signed in as opposed to on sign up to
avoid additional logic for FB or other social logins that may become cumbersome.
