### PR TITLE
Twitter Login Specs

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -51,9 +51,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
         flash[:notice] = "Successfully signed in with #{provider.capitalize}!"
         sign_in_and_redirect user, event: :authentication
-
       end
-
     end
   end
 

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -16,7 +16,6 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       identity = Identity.find_or_initialize_from_omniauth(auth)
 
       if user_signed_in? # User is connecting from settings page; only can connect new services
-
         if identity.new_record? # should always be this case since they can't connect existing services
           identity.update!(user: current_user)
           current_user.send("update_from_#{provider}", auth)
@@ -28,9 +27,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
         end
 
         redirect_to edit_user_registration_path(setting: 'account')
-
       else
-
         user = identity.user
         if user.nil? # Identity is new record
           user = User.find_by(email: email)
@@ -52,6 +49,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
         flash[:notice] = "Successfully signed in with #{provider.capitalize}!"
         sign_in_and_redirect user, event: :authentication
       end
+
     end
   end
 

--- a/spec/requests/omniauth_facebook_authorize_spec.rb
+++ b/spec/requests/omniauth_facebook_authorize_spec.rb
@@ -35,14 +35,24 @@ RSpec.describe 'Facebook OAuth authorization', type: :request do
     oauth_strategy.merge(data: { invalid_credentials: true })
   end
 
-  before { OmniAuth.config.mock_auth[oauth_strategy[:strategy]] = nil }
+  before do
+    OmniAuth.config.mock_auth[oauth_strategy[:strategy]] = nil
+    host! "#{ENV.fetch('SITE_HOST')}"
+  end
 
   context 'with valid login info for a new user' do
     before { omniauth_authenticate(valid_oauth_login) }
 
+    it 'redirects on submit' do
+      expect(response).to redirect_to user_facebook_omniauth_callback_path
+    end
+
     it 'creates a new user' do
-      expect(response).to be_redirect
       expect { follow_redirect! }.to change(User, :count).by(1)
+    end
+
+    it 'creates a new identity' do
+      expect { follow_redirect! }.to change(Identity, :count).by(1)
     end
 
     context 'following redirect' do
@@ -51,12 +61,17 @@ RSpec.describe 'Facebook OAuth authorization', type: :request do
       it 'sets the attributes on the user' do
         user = User.last
         info = valid_oauth_login[:data][:info]
+
         expect(user.first_name).to eq info[:first_name]
         expect(user.last_name).to eq info[:last_name]
-        expect(user.location).to eq info[:location]
         expect(user.email).to eq email.downcase
+        expect(user.location).to eq info[:location]
         expect(user.avatar_option).to eq provider
         expect(user.avatar.url).to include email.downcase
+      end
+
+      it 'displays the expected flash message' do
+        expect(flash[:notice]).to match('Successfully signed in with Facebook!')
       end
 
       it 'redirects to complete profile path' do
@@ -67,32 +82,34 @@ RSpec.describe 'Facebook OAuth authorization', type: :request do
 
   context 'with valid login info for an existing user with same uid/provider' do
     let!(:user) { create(:user) }
-    let!(:identity) { create(:identity, provider: provider, uid: uid, user: user)}
+    let!(:identity) { create(:identity, provider: provider, uid: uid, user: user) }
+    before { omniauth_authenticate(valid_oauth_login) }
 
-    before(:each) do
-      omniauth_authenticate(valid_oauth_login)
-    end
-
-    it 'redirects to callback' do
+    it 'redirects on submit' do
       expect(response).to redirect_to user_facebook_omniauth_callback_path
     end
 
-    context 'redirect to callback' do
-      before do
-        follow_redirect!
-      end
+    it 'DOES NOT create a new user' do
+      expect { follow_redirect! }.not_to change(User, :count)
+    end
 
-      it 'redirects to root path' do
-        expect(response).to redirect_to root_path
-      end
+    it 'DOES NOT create a new identity' do
+      expect { follow_redirect! }.not_to change(Identity, :count)
+    end
 
-      it 'does not create a new user' do
-        expect_any_instance_of(User).not_to receive(:update_from_omniauth)
-        expect { follow_redirect! }.not_to change(User, :count)
+    context 'following redirect' do
+      before { follow_redirect! }
+
+      it 'does not update user' do
+        expect_any_instance_of(User).not_to receive(:update_from_facebook)
       end
 
       it 'displays the expected flash message' do
         expect(flash[:notice]).to match('Successfully signed in with Facebook!')
+      end
+
+      it 'redirects to root path' do
+        expect(response).to redirect_to root_path
       end
     end
   end
@@ -101,55 +118,38 @@ RSpec.describe 'Facebook OAuth authorization', type: :request do
     let!(:user) { create(:user, email: email) }
     before { omniauth_authenticate(valid_oauth_login) }
 
+    it 'redirects on submit' do
+      expect(response).to redirect_to user_facebook_omniauth_callback_path
+    end
+
     it 'DOES NOT create a new user' do
-      expect(response).to be_redirect
       expect { follow_redirect! }.not_to change(User, :count)
+    end
+
+    it 'creates a new identity' do
+      expect { follow_redirect! }.to change(Identity, :count).by(1)
     end
 
     context 'following redirect' do
       before { follow_redirect! }
 
-      it 'redirects to root path' do
-        expect(response).to redirect_to root_path
-      end
-
-      it 'displays the expected flash message' do
-        expect(flash[:notice]).to match('Successfully signed in with Facebook!')
-      end
-
       it 'updates their profile with oauth credentials but not name' do
         user = User.last
         info = valid_oauth_login[:data][:info]
+
         expect(user.first_name).not_to eq info[:first_name]
         expect(user.last_name).not_to eq info[:last_name]
         expect(user.location).to eq info[:location]
         expect(user.avatar_option).to eq provider
         expect(user.avatar.url).to include email.downcase
       end
-    end
-  end
-
-  context 'with valid login info for an existing user with same email/uid' do
-    let!(:user) { create(:user, email: email) }
-    let!(:identity) { create(:identity, uid: uid, user: user)}
-
-    before { omniauth_authenticate(valid_oauth_login) }
-
-    context 'following redirect' do
-      before do
-        follow_redirect!
-      end
-
-      it 'redirects to root path' do
-        expect(response).to redirect_to root_path
-      end
 
       it 'displays the expected flash message' do
         expect(flash[:notice]).to match('Successfully signed in with Facebook!')
       end
 
-      it 'does not create a new user' do
-        expect{ follow_redirect! }.not_to change(User, :count)
+      it 'redirects to root path' do
+        expect(response).to redirect_to root_path
       end
     end
   end
@@ -157,8 +157,16 @@ RSpec.describe 'Facebook OAuth authorization', type: :request do
   context 'with invalid login info for a new user' do
     before { omniauth_authenticate(invalid_oauth_login) }
 
-    it 'redirects to callback' do
-      expect(response).to be_redirect
+    it 'redirects on submit' do
+      expect(response).to redirect_to user_facebook_omniauth_callback_path
+    end
+
+    it 'DOES NOT create a new user' do
+      expect { follow_redirect! }.not_to change(User, :count)
+    end
+
+    it 'DOES NOT create a new identity' do
+      expect { follow_redirect! }.not_to change(Identity, :count)
     end
 
     context 'following redirect' do
@@ -167,10 +175,6 @@ RSpec.describe 'Facebook OAuth authorization', type: :request do
       it 'redirects to the failure callback' do
         expect(response).to redirect_to '/users/auth/failure?message=invalid_credentials&strategy=facebook'
       end
-    end
-
-    it 'does NOT create a new user' do
-      expect { follow_redirect! }.not_to change(User, :count)
     end
   end
 

--- a/spec/requests/omniauth_facebook_authorize_spec.rb
+++ b/spec/requests/omniauth_facebook_authorize_spec.rb
@@ -97,70 +97,81 @@ RSpec.describe 'Facebook OAuth authorization', type: :request do
     end
   end
 
-  # context 'with valid login info for an existing user with same email' do
-  #   let!(:user) { create(:user, email: email) }
-  #   before { omniauth_authenticate(valid_oauth_login) }
+  context 'with valid login info for an existing user with same email' do
+    let!(:user) { create(:user, email: email) }
+    before { omniauth_authenticate(valid_oauth_login) }
 
-  #   it 'DOES NOT create a new user' do
-  #     expect(response).to be_redirect
-  #     expect { follow_redirect! }.not_to change(User, :count)
-  #   end
+    it 'DOES NOT create a new user' do
+      expect(response).to be_redirect
+      expect { follow_redirect! }.not_to change(User, :count)
+    end
 
-  #   context 'following redirect' do
-  #     before { follow_redirect! }
+    context 'following redirect' do
+      before { follow_redirect! }
 
-  #     it 'redirects to root path' do
-  #       expect(response).to redirect_to root_path
-  #     end
+      it 'redirects to root path' do
+        expect(response).to redirect_to root_path
+      end
 
-  #     it 'updates their profile with oauth credentials but not name' do
-  #       user = User.last
-  #       info = valid_oauth_login[:data][:info]
-  #       expect(user.first_name).not_to eq info[:first_name]
-  #       expect(user.last_name).not_to eq info[:last_name]
-  #       expect(user.location).to eq info[:location]
-  #       expect(user.avatar_option).to eq provider
-  #       expect(user.avatar.url).to include uid
-  #     end
-  #   end
-  # end
+      it 'displays the expected flash message' do
+        expect(flash[:notice]).to match('Successfully signed in with Facebook!')
+      end
 
-  # context 'with valid login info for an existing user with same email/uid' do
-  #   let!(:user) { create(:user, email: email, uid: uid) }
-  #   before { omniauth_authenticate(valid_oauth_login) }
+      it 'updates their profile with oauth credentials but not name' do
+        user = User.last
+        info = valid_oauth_login[:data][:info]
+        expect(user.first_name).not_to eq info[:first_name]
+        expect(user.last_name).not_to eq info[:last_name]
+        expect(user.location).to eq info[:location]
+        expect(user.avatar_option).to eq provider
+        expect(user.avatar.url).to include email.downcase
+      end
+    end
+  end
 
-  #   it 'DOES NOT create a new user' do
-  #     expect(response).to be_redirect
-  #     expect { follow_redirect! }.not_to change(User, :count)
-  #   end
+  context 'with valid login info for an existing user with same email/uid' do
+    let!(:user) { create(:user, email: email) }
+    let!(:identity) { create(:identity, uid: uid, user: user)}
 
-  #   context 'following redirect' do
-  #     before do
-  #       expect_any_instance_of(User).not_to receive(:update_from_omniauth)
-  #       follow_redirect!
-  #     end
+    before { omniauth_authenticate(valid_oauth_login) }
 
-  #     it 'redirects to root path' do
-  #       expect(response).to redirect_to root_path
-  #     end
-  #   end
-  # end
+    context 'following redirect' do
+      before do
+        follow_redirect!
+      end
 
-  # context 'with invalid login info for a new user' do
-  #   before { omniauth_authenticate(invalid_oauth_login) }
+      it 'redirects to root path' do
+        expect(response).to redirect_to root_path
+      end
 
-  #   it 'does NOT create a new user' do
-  #     expect(response).to be_redirect
-  #     expect { follow_redirect! }.not_to change(User, :count)
-  #   end
+      it 'displays the expected flash message' do
+        expect(flash[:notice]).to match('Successfully signed in with Facebook!')
+      end
 
-  #   context 'following redirect' do
-  #     before { follow_redirect! }
+      it 'does not create a new user' do
+        expect{ follow_redirect! }.not_to change(User, :count)
+      end
+    end
+  end
 
-  #     it 'redirects to the failure callback' do
-  #       expect(response).to redirect_to '/users/auth/failure?message=invalid_credentials&strategy=facebook'
-  #     end
-  #   end
-  # end
+  context 'with invalid login info for a new user' do
+    before { omniauth_authenticate(invalid_oauth_login) }
+
+    it 'redirects to callback' do
+      expect(response).to be_redirect
+    end
+
+    context 'following redirect' do
+      before { follow_redirect! }
+
+      it 'redirects to the failure callback' do
+        expect(response).to redirect_to '/users/auth/failure?message=invalid_credentials&strategy=facebook'
+      end
+    end
+
+    it 'does NOT create a new user' do
+      expect { follow_redirect! }.not_to change(User, :count)
+    end
+  end
 
 end

--- a/spec/requests/omniauth_twitter_authorize_spec.rb
+++ b/spec/requests/omniauth_twitter_authorize_spec.rb
@@ -76,5 +76,114 @@ RSpec.describe 'Twitter OAuth authorization', type: :request do
     end
   end
 
+  context 'with valid login info for an existing user with same uid/provider' do
+    let!(:user) { create(:user) }
+    let!(:identity) { create(:identity, provider: provider, uid: uid, user: user)}
+
+    before(:each) do
+      omniauth_authenticate(valid_oauth_login)
+    end
+
+    it 'redirects to callback' do
+      expect(response).to redirect_to user_twitter_omniauth_callback_path
+    end
+
+    context 'redirect to callback' do
+      before do
+        follow_redirect!
+      end
+
+      it 'redirects to root path' do
+        expect(response).to redirect_to root_path
+      end
+
+      it 'does not create a new user' do
+        # binding.pry
+        expect_any_instance_of(User.class).not_to receive(:update_from_omniauth)
+        expect { follow_redirect! }.not_to change(User, :count)
+      end
+
+      it 'displays the expected flash message' do
+        expect(flash[:notice]).to match('Successfully signed in with Twitter!')
+      end
+    end
+  end
+
+  context 'with valid login info for an existing user with same email' do
+    let!(:user) { create(:user, email: email) }
+    before { omniauth_authenticate(valid_oauth_login) }
+
+    it 'DOES NOT create a new user' do
+      expect(response).to be_redirect
+      expect { follow_redirect! }.not_to change(User, :count)
+    end
+
+    context 'following redirect' do
+      before { follow_redirect! }
+
+      it 'redirects to root path' do
+        expect(response).to redirect_to root_path
+      end
+
+      it 'displays the expected flash message' do
+        expect(flash[:notice]).to match('Successfully signed in with Twitter!')
+      end
+
+      it 'updates their profile with oauth credentials but not name' do
+        user = User.last
+        info = valid_oauth_login[:data][:info]
+        expect(user.first_name).not_to eq info[:first_name]
+        expect(user.last_name).not_to eq info[:last_name]
+        expect(user.location).to eq info[:location]
+        expect(user.avatar_option).to eq provider
+        expect(user.avatar.url).to include info[:nickname]
+      end
+    end
+  end
+
+  context 'with valid login info for an existing user with same email/uid' do
+    let!(:user) { create(:user, email: email) }
+    let!(:identity) { create(:identity, uid: uid, user: user)}
+
+    before { omniauth_authenticate(valid_oauth_login) }
+
+    context 'following redirect' do
+      before do
+        follow_redirect!
+      end
+
+      it 'redirects to root path' do
+        expect(response).to redirect_to root_path
+      end
+
+      it 'displays the expected flash message' do
+        expect(flash[:notice]).to match('Successfully signed in with Twitter!')
+      end
+
+      it 'does not create a new user' do
+        expect{ follow_redirect! }.not_to change(User, :count)
+      end
+    end
+  end
+
+  context 'with invalid login info for a new user' do
+    before { omniauth_authenticate(invalid_oauth_login) }
+
+    it 'redirects to callback' do
+      expect(response).to be_redirect
+    end
+
+    context 'following redirect' do
+      before { follow_redirect! }
+
+      it 'redirects to the failure callback' do
+        expect(response).to redirect_to '/users/auth/failure?message=invalid_credentials&strategy=twitter'
+      end
+    end
+
+    it 'does NOT create a new user' do
+      expect { follow_redirect! }.not_to change(User, :count)
+    end
+  end
 
 end

--- a/spec/requests/omniauth_twitter_authorize_spec.rb
+++ b/spec/requests/omniauth_twitter_authorize_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+require 'support/omniauth_helpers'
+
+RSpec.describe 'Twitter OAuth authorization', type: :request do
+
+  let(:provider) { 'twitter' }
+  let(:uid) { '12345' }
+  let(:email) { 'TEST@EXAMPLE.COM' }
+
+  let(:oauth_strategy) { { strategy: provider } }
+  let(:valid_oauth_login) do
+    oauth_strategy.merge(
+      data: {
+        provider: provider,
+        uid: uid,
+        info: {
+          nickname:  'twitterhandle',
+          name:      'Gaius Baltar',
+          email:     email,
+          location:  'San Francisco',
+          image:      'https://pbs.twimg.com/profile_images/758137943970222080/erL8FDMo_normal.jpg',
+          description: 'Oauth Twitter test robot. Here to serve humans.'
+        },
+        credentials: {
+          token: '123456',
+          expires_at: Time.now + 1.week
+        },
+        extra: {
+          raw_info: {
+            gender: 'male'
+          }
+        }
+      }
+    )
+  end
+  let(:invalid_oauth_login) do
+    oauth_strategy.merge(data: { invalid_credentials: true })
+  end
+
+  before { OmniAuth.config.mock_auth[oauth_strategy[:strategy]] = nil }
+
+  context 'with valid login infor for a new user' do
+    before { omniauth_authenticate(valid_oauth_login) }
+
+    it 'creates a new user' do
+      expect(response).to be_redirect
+      expect { follow_redirect! }.to change(User, :count).by(1)
+    end
+  end
+end

--- a/spec/requests/omniauth_twitter_authorize_spec.rb
+++ b/spec/requests/omniauth_twitter_authorize_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe 'Twitter OAuth authorization', type: :request do
     OmniAuth.config.mock_auth[oauth_strategy[:strategy]] = nil
 
     stub_request(:get, "https://pbs.twimg.com/profile_images/test_user_profile/erL8FDMo_400x400.jpg").
-      with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Ruby'}).
-      to_return(:status => 200, :body => "", :headers => {})
+      with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Ruby'}).
+      to_return(status: 200, body: "", headers: {})
   end
 
   context 'with valid login info for a new user' do
@@ -69,7 +69,7 @@ RSpec.describe 'Twitter OAuth authorization', type: :request do
 
         expect(user.first_name).to eq info[:name].split(' ').first
         expect(user.last_name).to eq info[:name].split(' ').last
-        expect(user.email).to eq info[:email].downcase
+        expect(user.email).to eq email.downcase
         expect(user.location).to eq info[:location]
         expect(user.avatar_option).to eq provider
         expect(user.avatar.url).to include info[:nickname]
@@ -88,7 +88,7 @@ RSpec.describe 'Twitter OAuth authorization', type: :request do
 
   context 'with valid login info for an existing user with same uid/provider' do
     let!(:user) { create(:user) }
-    let!(:identity) { create(:identity, provider: provider, uid: uid, user: user)}
+    let!(:identity) { create(:identity, provider: provider, uid: uid, user: user) }
     before { omniauth_authenticate(valid_oauth_login) }
 
     it 'redirects on submit' do
@@ -106,7 +106,7 @@ RSpec.describe 'Twitter OAuth authorization', type: :request do
     context 'following redirect' do
       before { follow_redirect! }
 
-      it 'does not update from twitter' do
+      it 'does not update user' do
         expect_any_instance_of(User).not_to receive(:update_from_twitter)
       end
 


### PR DESCRIPTION
- [x] get existing Facebook login tests green
- [x] write new tests to cover:
  - [ ] Identity controller: disassociating from twitter and facebook
  - [x] Twitter login

Questions:

```
  1) Facebook OAuth authorization with valid login info for an existing user with same uid/provider redirects to callback
     Failure/Error: expect(response).to redirect_to user_facebook_omniauth_callback_path

       Expected response to be a redirect to <http://www.example.com/users/auth/facebook/callback> but was a redirect to <http://localhost:3000/users/auth/facebook/callback>.
       Expected "http://www.example.com/users/auth/facebook/callback" to be === "http://localhost:3000/users/auth/facebook/callback".
     # ./spec/requests/omniauth_facebook_authorize_spec.rb:77:in `block (3 levels) in <top (required)>'
```

```
  2) Facebook OAuth authorization with valid login info for an existing user with same uid/provider redirect to callback does not create a new user
     Failure/Error: expect_any_instance_of(User).not_to receive(:update_from_omniauth)
       User does not implement #update_from_omniauth
     # ./spec/requests/omniauth_facebook_authorize_spec.rb:90:in `block (4 levels) in <top (required)>'
```
