### PR TITLE
Refactor the Progress Bar

### DIFF
--- a/app/assets/stylesheets/pages/challenge.sass
+++ b/app/assets/stylesheets/pages/challenge.sass
@@ -27,55 +27,23 @@
     flex: 1
     flex-direction: column
     &:hover,&:focus,&:active,&.active
-      text-decoration: none
-    &.experience-bg
-      &.active
-        .stage-experience
-          @extend .experience,.text-experience
+    text-decoration: none
+  .default_stage
+    @extend .text-small
+    color: $lightGrayText
+    line-height: 2em
+    background-color: transparent
+    border-style: solid
+    border-width: 0
+    border-radius: 0
+    text-align: left
+    @media only screen and (max-width: $screen-sm)
+      text-align: center
+    &.hover-solution
       &:hover,&:focus,&:active,&.selected
-        background-color: rgba($experience, 0.2)
-        .stage-experience
-          @extend .experience,.text-experience,.bar-experience
-    &.idea-bg
-      &.active
-        .stage-idea
-          @extend .idea,.text-idea
-      &:hover,&:focus,&:active,&.selected
-        background-color: rgba($idea, 0.2)
-        .stage-idea
-          @extend .idea,.text-idea,.bar-idea
-    &.recipe-bg
-      &.active
-        .stage-recipe
-          @extend .recipe,.text-recipe
-      &:hover,&:focus,&:active,&.selected
-        background-color: rgba($recipe, 0.2)
-        .stage-recipe
-          @extend .recipe,.text-recipe,.bar-recipe
-    &.solution-bg
-      &.active
-        .stage-solution
-          @extend .solution,.text-solution
-      &:hover,&:focus,&:active,&.selected
-        background-color: rgba($solution, 0.2)
-        @extend .text-solution
-        .stage-solution
-          @extend .solution,.text-solution,.bar-solution
-    .default_stage
-      @extend .text-small
-      color: $lightGrayText
-      line-height: 2em
-      background-color: transparent
-      border-style: solid
-      border-width: 0
+        @extend .solution,.text-solution
+    .body
       padding: $padding-base-horizontal $padding-xl-vertical
-      border-radius: 0
-      text-align: left
-      @media only screen and (max-width: $screen-sm)
-        text-align: center
-      &.hover-solution
-        &:hover,&:focus,&:active,&.selected
-          @extend .solution,.text-solution
       .headline
         @extend .text-medium
         @extend .hidden-xs
@@ -85,20 +53,74 @@
         @extend .visible-xs
         @extend .text-bolder
         line-height: $font-size-small
-    .pre-active_stage
-      @extend .text-default
-
     .bottom-bar
       height: $padding-base-vertical
-      background-color: rgba($lightGrayText, 0.2)
-      &.bar-experience
+      background-color: rgba($text-color, 0.2)
+    &.experience
+      &:hover,&:focus,&:active,&.selected
+        @extend .experience,.text-experience
+        background-color: rgba($experience, 0.2)
+        .bottom-bar
+          background-color: $experience
+    &.idea
+      &:hover,&:focus,&:active,&.selected
+        @extend .idea,.text-idea
+        background-color: rgba($idea, 0.2)
+        .bottom-bar
+          background-color: $idea
+    &.recipe
+      &:hover,&:focus,&:active,&.selected
+        @extend .recipe,.text-recipe
+        background-color: rgba($recipe, 0.2)
+        .bottom-bar
+          background-color: $recipe
+    &.solution
+      &:hover,&:focus,&:active,&.selected
+        background-color: rgba($solution, 0.2)
+        @extend .solution,.text-solution
+        .bottom-bar
+          background-color: $solution
+  .past_stage
+    @extend .text-default
+    .bottom-bar
+      &.experience
         background-color: $experience
-      &.bar-idea
+      &.idea
         background-color: $idea
-      &.bar-recipe
+      &.recipe
         background-color: $recipe
-      &.bar-solution
+      &.solution
         background-color: $solution
+  .current_stage
+    &.experience
+      @extend .text-experience
+      .bottom-bar
+        background: repeating-linear-gradient(45deg, $experience, $experience 10px, rgba($text-color, 0.2) 10px, rgba($text-color, 0.2) 20px)
+    &.idea
+      @extend .text-idea
+      .bottom-bar
+        background: repeating-linear-gradient(45deg, $idea, $idea 10px, rgba($text-color, 0.2) 10px, rgba($text-color, 0.2) 20px)
+    &.recipe
+      @extend .text-recipe
+      .bottom-bar
+        background: repeating-linear-gradient(45deg, $recipe, $recipe 10px, rgba($text-color, 0.2) 10px, rgba($text-color, 0.2) 20px)
+    &.solution
+      @extend .text-solution
+      .bottom-bar
+        background: repeating-linear-gradient(45deg, $solution, $solution 10px, rgba($text-color, 0.2) 10px, rgba($text-color, 0.2) 20px)
+  .selected_stage
+    &.experience
+      @extend .text-experience
+      background-color: rgba($experience, 0.2)
+    &.idea
+      @extend .text-idea
+      background-color: rgba($idea, 0.2)
+    &.recipe
+      @extend .text-recipe
+      background-color: rgba($recipe, 0.2)
+    &.solution
+      @extend .text-solution
+      background-color: rgba($solution, 0.2)
 
   .fa-angle-right
     color: #CECFD0
@@ -111,7 +133,7 @@
   .solution
     border-color: $solution
 
-  .background-descriptor-container
+  .descriptor-container
     @background .hidden-xs,.text-bold,.text-default,.text-small
     display: flex
     flex: 1

--- a/app/assets/stylesheets/pages/challenge.sass
+++ b/app/assets/stylesheets/pages/challenge.sass
@@ -6,7 +6,7 @@
       padding-top: $padding-base-vertical
       padding-bottom: 0px
     .stage
-      border-width: 0 0 $padding-base-vertical 0
+      border-width: 0
       .headline
         @extend .text-small
         line-height: $font-size-small
@@ -35,7 +35,7 @@
       &:hover,&:focus,&:active,&.selected
         background-color: rgba($experience, 0.2)
         .stage-experience
-          @extend .experience,.text-experience
+          @extend .experience,.text-experience,.bar-experience
     &.idea-bg
       &.active
         .stage-idea
@@ -43,7 +43,7 @@
       &:hover,&:focus,&:active,&.selected
         background-color: rgba($idea, 0.2)
         .stage-idea
-          @extend .idea,.text-idea
+          @extend .idea,.text-idea,.bar-idea
     &.recipe-bg
       &.active
         .stage-recipe
@@ -51,36 +51,55 @@
       &:hover,&:focus,&:active,&.selected
         background-color: rgba($recipe, 0.2)
         .stage-recipe
-          @extend .recipe,.text-recipe
+          @extend .recipe,.text-recipe,.bar-recipe
     &.solution-bg
       &.active
         .stage-solution
           @extend .solution,.text-solution
       &:hover,&:focus,&:active,&.selected
         background-color: rgba($solution, 0.2)
+        @extend .text-solution
         .stage-solution
-          @extend .solution,.text-solution
-  .stage
-    @extend .text-small
-    color: $lightGrayText
-    line-height: 2em
-    background-color: transparent
-    border-style: solid
-    border-width: 0 0 $padding-large-vertical 0
-    padding: $padding-base-horizontal $padding-xl-vertical
-    border-radius: 0
-    text-align: left
-    @media only screen and (max-width: $screen-sm)
-      text-align: center
-    .headline
-      @extend .text-medium
-      @extend .hidden-xs
-      @extend .text-bolder
-    .headline-xs
+          @extend .solution,.text-solution,.bar-solution
+    .default_stage
       @extend .text-small
-      @extend .visible-xs
-      @extend .text-bolder
-      line-height: $font-size-small
+      color: $lightGrayText
+      line-height: 2em
+      background-color: transparent
+      border-style: solid
+      border-width: 0
+      padding: $padding-base-horizontal $padding-xl-vertical
+      border-radius: 0
+      text-align: left
+      @media only screen and (max-width: $screen-sm)
+        text-align: center
+      &.hover-solution
+        &:hover,&:focus,&:active,&.selected
+          @extend .solution,.text-solution
+      .headline
+        @extend .text-medium
+        @extend .hidden-xs
+        @extend .text-bolder
+      .headline-xs
+        @extend .text-small
+        @extend .visible-xs
+        @extend .text-bolder
+        line-height: $font-size-small
+    .pre-active_stage
+      @extend .text-default
+
+    .bottom-bar
+      height: $padding-base-vertical
+      background-color: rgba($lightGrayText, 0.2)
+      &.bar-experience
+        background-color: $experience
+      &.bar-idea
+        background-color: $idea
+      &.bar-recipe
+        background-color: $recipe
+      &.bar-solution
+        background-color: $solution
+
   .fa-angle-right
     color: #CECFD0
   .experience
@@ -91,8 +110,9 @@
     border-color: $recipe
   .solution
     border-color: $solution
-  .descriptor-container
-    @extend .hidden-xs,.text-bold,.text-default,.text-small
+
+  .background-descriptor-container
+    @background .hidden-xs,.text-bold,.text-default,.text-small
     display: flex
     flex: 1
     align-items: stretch

--- a/app/views/challenges/_header.html.erb
+++ b/app/views/challenges/_header.html.erb
@@ -5,23 +5,23 @@
 
         <div id='challenge-nav'>
           <% Challenge::STAGES.each_with_index do |stage, index| %>
+            <% current_stage = stage[:name] == @challenge.active_stage %>
             <%= link_to eval("challenge_#{stage[:name]}_stage_path(@challenge, @challenge.#{stage[:name]}_stage)"), class: "stage-container #{stage[:name]}-bg #{ 'selected' if @challenge.stage_number > 4 || eval("params[:#{stage[:name]}_stage_id] || @#{stage[:name]}_stage") }" do %>
 
-              <div class="stage stage-<%= stage[:name] %> <%= "text-default #{@challenge.active_stage}" if @challenge.stage_number >= stage[:number] %>">
+              <div class="default_stage <%= "pre-active_stage" if @challenge.stage_number > stage[:number] %> hover-<%= stage[:name] %> <%= "stage-#{stage[:name]} #{@challenge.active_stage}" if @challenge.stage_number >= stage[:number] %>">
 
-                <% if stage[:name] == @challenge.active_stage %>
-                    <i class="fa fa-2x <%= stage[:icon] %> text-<%= stage[:name] %>"></i>
-                <% else %>
-                  <i class='fa fa-2x <%= stage[:icon] %>'></i>
-                <% end %>
+                <i class="fa fa-2x <%= stage[:icon] %> <%= "text-#{stage[:name]}" if current_stage %>"></i>
 
-                <div class='headline text-<%= stage[:name] if @challenge.stage_number == stage[:number] %>'><%= stage[:headline] %></div>
-                <div class='headline-xs text-<%= stage[:name] if @challenge.stage_number == stage[:number] %>'><%= stage[:headline].split(' ').first %></div>
+                <div class='headline text-<%= stage[:name] if current_stage %>'><%= stage[:headline] %></div>
+                <div class='headline-xs text-<%= stage[:name] if current_stage %>'><%= stage[:headline].split(' ').first %></div>
+              </div>
+
+              <div class="bottom-bar bar-<%= @challenge.active_stage if @challenge.stage_number >= stage[:number] %> <%= "stage-#{stage[:name]}" %>">
               </div>
 
               <div class="descriptor-container">
 
-                <% if stage[:name] == @challenge.active_stage %>
+                <% if current_stage %>
                   <div class="in-progress">In progress</div>
                 <% elsif stage[:number] < @challenge.stage_number %>
                   <!-- We don't want to display 0 counts. -->

--- a/app/views/challenges/_header.html.erb
+++ b/app/views/challenges/_header.html.erb
@@ -6,17 +6,25 @@
         <div id='challenge-nav'>
           <% Challenge::STAGES.each_with_index do |stage, index| %>
             <% current_stage = stage[:name] == @challenge.active_stage %>
-            <%= link_to eval("challenge_#{stage[:name]}_stage_path(@challenge, @challenge.#{stage[:name]}_stage)"), class: "stage-container #{stage[:name]}-bg #{ 'selected' if @challenge.stage_number > 4 || eval("params[:#{stage[:name]}_stage_id] || @#{stage[:name]}_stage") }" do %>
+            <% selected_stage = @challenge.stage_number > 4 || eval("params[:#{stage[:name]}_stage_id] || @#{stage[:name]}_stage") %>
+            <% past_stage = @challenge.stage_number >= stage[:number] %>
 
-              <div class="default_stage <%= "pre-active_stage" if @challenge.stage_number > stage[:number] %> hover-<%= stage[:name] %> <%= "stage-#{stage[:name]} #{@challenge.active_stage}" if @challenge.stage_number >= stage[:number] %>">
+            <%= link_to eval("challenge_#{stage[:name]}_stage_path(@challenge, @challenge.#{stage[:name]}_stage)"), class:
+              "stage-container
+                default_stage
+                #{ 'past_stage' if past_stage }
+                #{ 'current_stage' if current_stage }
+                #{ 'selected_stage' if selected_stage }
+                #{stage[:name]}" do %>
 
+              <div class='body'>
                 <i class="fa fa-2x <%= stage[:icon] %> <%= "text-#{stage[:name]}" if current_stage %>"></i>
 
-                <div class='headline text-<%= stage[:name] if current_stage %>'><%= stage[:headline] %></div>
-                <div class='headline-xs text-<%= stage[:name] if current_stage %>'><%= stage[:headline].split(' ').first %></div>
+                <div class='headline'><%= stage[:headline] %></div>
+                <div class='headline-xs'><%= stage[:headline].split(' ').first %></div>
               </div>
 
-              <div class="bottom-bar bar-<%= @challenge.active_stage if @challenge.stage_number >= stage[:number] %> <%= "stage-#{stage[:name]}" %>">
+              <div class="bottom-bar <%= @challenge.active_stage if past_stage %>">
               </div>
 
               <div class="descriptor-container">


### PR DESCRIPTION
4 simple styles, applied in order:
`.default_stage`
 - Sets up basic styling that applies by default to all elements of the progress bar.

`.past_stage`
 - Applies to any stage at or before the current "active_stage".
   - bottom bar color
   - darker text color

`.current_stage`
 - Always maintains its stage text and icon color

`.selected_stage`
 - Applies to the stage that's "selected", i.e. corresponding to the stage page we're on.
